### PR TITLE
added extra check in indieweb_publisher_auto_featured_image_post_cover

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -407,7 +407,7 @@ function indieweb_publisher_featured_image_meta( $content ) {
 	 If Auto-Set Featured Image as Post Cover enabled, this checkbox's functionality should reverse and
 	 * allow for disabling Post Covers on a post-by-post basis.
 	 */
-	if ( indieweb_publisher_auto_featured_image_post_cover() ) {
+	if ( function_exists('indieweb_publisher_auto_featured_image_post_cover') && indieweb_publisher_auto_featured_image_post_cover() ) {	
 		$meta_key    = 'full_width_featured_image_disabled';
 		$text        = __( 'Disable post cover (full-width)', 'indieweb-publisher' );
 		$option_type = 'disable';


### PR DESCRIPTION
The extra check if the function indieweb_publisher_auto_featured_image_post_cover exists makes sure it doesn't break the post admin screen. 
Before the extra check it gave the error 
`Uncaught Error: Call to undefined function indieweb_publisher_auto_featured_image_post_cover() in /app/public/wp-content/themes/indieweb-publisher/inc/template-functions.php on line 410` when you opened an existing post with featured image. 